### PR TITLE
Remove o-expander hooks

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -1,7 +1,6 @@
 <div class="ad-placeholder ad-placeholder__banlb ad-placeholder__{{__name}}"></div>
 <header
-	class="next-header o-expander"
-	data-o-component="o-expander"
+	class="next-header"
 	data-trackable="header" >
 	<div class="next-header__row next-header__row--primary">
 		<div class="next-header__row--inner o-grid-row">


### PR DESCRIPTION
Only expanding in header is done in the `next-navigation` component