### PR TITLE
Don't throw error for notifications with anonymous

### DIFF
--- a/src/js/notified.js
+++ b/src/js/notified.js
@@ -32,7 +32,7 @@ module.exports = {
 			var notifications = ev.detail;
 			var count = parseInt(notifications.Count, 10);
 			var myPageLink = document.querySelector('.js-my-page-tool');
-			
+
 			// HACK: Handle anonymous user. Won't be needed once we're fully on the new membership APIs
 			if (!myPageLink) {
 				return;

--- a/src/js/notified.js
+++ b/src/js/notified.js
@@ -32,7 +32,8 @@ module.exports = {
 			var notifications = ev.detail;
 			var count = parseInt(notifications.Count, 10);
 			var myPageLink = document.querySelector('.js-my-page-tool');
-			// Handle anonymous user
+			
+			// HACK: Handle anonymous user. Won't be needed once we're fully on the new membership APIs
 			if (!myPageLink) {
 				return;
 			}

--- a/src/js/notified.js
+++ b/src/js/notified.js
@@ -32,7 +32,10 @@ module.exports = {
 			var notifications = ev.detail;
 			var count = parseInt(notifications.Count, 10);
 			var myPageLink = document.querySelector('.js-my-page-tool');
-
+			// Handle anonymous user
+			if (!myPageLink) {
+				return;
+			}
 			var seenCount = getSeenCount();
 			setSeenCount(count);
 


### PR DESCRIPTION
If a user has a valid session but we think they're not logged in (due to barrier running on legacy membership stuff) we can have a situation where myft notifications are fetched but there's nothing in the UI to update. This fixes that.

@adgad @adamsilver 