### PR TITLE
Add accessibility skip links

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -1,11 +1,11 @@
 @import "next-sass-setup/main";
-
 $o-forms-is-silent: false;
 @import "o-forms/main";
 @import "o-grid/main";
 
 @import "next-navigation/main";
 
+@import "src/scss/helpers";
 @import "src/scss/vars_mixins";
 @import "src/scss/header/base";
 @import "src/scss/header/logo";

--- a/src/scss/_helpers.scss
+++ b/src/scss/_helpers.scss
@@ -1,0 +1,10 @@
+.u-visually-hidden {
+	position: absolute;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	width: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+}

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,3 +1,5 @@
+<a class="u-visually-hidden" href="#primary-nav">Skip to navigation</a>
+<a class="u-visually-hidden" href="#site-content">Skip to content</a>
 <div class="ad-placeholder ad-placeholder__banlb ad-placeholder__{{__name}}"></div>
 <header
 	class="next-header"


### PR DESCRIPTION
Adds hidden skip links to the top of the document enabling users using assistive technologies to jump to core sections of the page.

##### Potential improvements
- We could go further and follow GitHub's pattern by adding a `tab-index=1"` and visually exposing the element when focused?

/cc @i-like-robots @matthew-andrews 