### PR TITLE
Tidy up font/color usage

### DIFF
--- a/src/scss/_vars_mixins.scss
+++ b/src/scss/_vars_mixins.scss
@@ -3,7 +3,6 @@ $next-header-primary-bg: #222222;
 $next-header-secondary-bg: oColorsGetPaletteColor(grey-tint5);
 
 @mixin nextHeaderNavItem() {
-	font-family: $fontSans;
 	color: $next-white;
 	text-decoration: none;
 	display: block;

--- a/src/scss/_vars_mixins.scss
+++ b/src/scss/_vars_mixins.scss
@@ -1,9 +1,9 @@
 $next-header-primary-height: 45px;
 $next-header-primary-bg: #222222;
-$next-header-secondary-bg: oColorsGetPaletteColor(grey-tint5);
+$next-header-secondary-bg: getColor('grey-tint5');
 
 @mixin nextHeaderNavItem() {
-	color: $next-white;
+	color: getColor('white');
 	text-decoration: none;
 	display: block;
 	line-height: $next-header-primary-height;

--- a/src/scss/footer/_main.scss
+++ b/src/scss/footer/_main.scss
@@ -3,7 +3,7 @@
 }
 
 .next-footer__nav {
-	background-color: $next-grey-dark;
+	background-color: getColor('cold-2');
 	display: none;
 
 	.no-js & {
@@ -21,14 +21,13 @@
 .next-footer__back-to-top {
 	margin: 5px;
 	a {
-		color: $next-grey-lighter;
+		color: getColor('white');
 		text-decoration: none;
 		padding: 5px;
 		display: inline-block;
 
 		&:hover {
-			background-color: $next-blue;
-			color: $next-white;
+			text-decoration: underline;
 		}
 	}
 }

--- a/src/scss/footer/_main.scss
+++ b/src/scss/footer/_main.scss
@@ -21,12 +21,11 @@
 .next-footer__back-to-top {
 	margin: 5px;
 	a {
-		font-family: $fontSans;
 		color: $next-grey-lighter;
 		text-decoration: none;
 		padding: 5px;
 		display: inline-block;
-		font-weight: 300;
+
 		&:hover {
 			background-color: $next-blue;
 			color: $next-white;

--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -1,5 +1,4 @@
 .next-header {
-	font-family: $fontSans;
 	position: relative;
 	z-index: 20;
 }

--- a/src/scss/header/_logo.scss
+++ b/src/scss/header/_logo.scss
@@ -36,15 +36,3 @@
 		border: 0;
 	}
 }
-
-@include nextHeaderOldIe {
-	.next-header__logo__name {
-		text-indent: 0;
-		text-align: center;
-		color: $next-black;
-		font-family: $fontBrand;
-		line-height: 35px;
-		font-size: 30px;
-		background-image: none;
-	}
-}

--- a/src/scss/header/_logo.scss
+++ b/src/scss/header/_logo.scss
@@ -20,7 +20,7 @@
 		left: 0;
 		text-align: center;
 		font-size: 10px;
-		color: $next-black;
+		color: getColor('black');
 	}
 }
 
@@ -30,7 +30,7 @@
 	margin-left: 5px;
 
 	.next-header__logo--ft & {
-		@include nextIcon(brand-ft, $next-black, 35);
+		@include nextIcon(brand-ft, getColor('black'), 35);
 		background-size: 35px 20px;
 		background-position: 0 8px;
 		border: 0;

--- a/src/scss/header/_logo.scss
+++ b/src/scss/header/_logo.scss
@@ -12,14 +12,13 @@
 	position: relative;
 
 	&:after {
+		@include nTypeBravo(5);
 		content: 'ALPHA';
 		position: absolute;
 		bottom: 2px;
 		right: 0;
 		left: 0;
 		text-align: center;
-		font-family: $fontSans;
-		font-weight: 500;
 		font-size: 10px;
 		color: $next-black;
 	}

--- a/src/scss/header/_print.scss
+++ b/src/scss/header/_print.scss
@@ -5,7 +5,6 @@
 	.next-header:after {
 		content: 'Financial Times';
 		display: block;
-		font-family: $fontSans;
 		text-transform: uppercase;
 		text-align: center;
 		font-size: 30px;


### PR DESCRIPTION
- Removes deprecated font vars (which were redundant now that the body specifies a default font-fam)
- Swaps `oColorsGetPaletteColor` calls with the `getColor` alias
- Jigs the footer's "Back to top" styling a bit
- Resolves an issue where the FT logo looks borked in IE 8