### PR TITLE
Fixed header collapsing on dolphin browser

### DIFF
--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -28,6 +28,7 @@
 }
 .next-header__row--inner {
 	position: relative;
+	min-height: 45px;
 }
 .next-header__row--primary {
 	background: $next-header-primary-bg;


### PR DESCRIPTION
Fixed this in dolphin:

![image](https://cloud.githubusercontent.com/assets/4622378/9852293/6a917002-5af5-11e5-9110-6fcba5f18607.png)

