### PR TITLE
handle ampersands in search terms better

### DIFF
--- a/src/js/typeahead.js
+++ b/src/js/typeahead.js
@@ -145,7 +145,7 @@ Suggest.prototype.onSuggestionKey = function (ev) {
 Suggest.prototype.getSuggestions = function (value) {
 	value = value.trim();
 	if (value.length >= this.minLength) {
-		fetch(this.dataSrc + value.replace(' ', '+'))
+		fetch(this.dataSrc + encodeURIComponent(value.replace(' ', '+')))
 			.then(function (response) {
 				if (!response.ok) {
 					throw new Error(response.statusText);


### PR DESCRIPTION
Along with https://github.com/Financial-Times/next-tme-search-api/pull/27 It means terms such as 'Science & technology' will be treated properly @charypar @ironsidevsquincy 