### PR TITLE
If something above header, use `sticky`

### DIFF
--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -8,7 +8,17 @@
 	@include oGridRespondTo(M) {
 		padding-bottom: 0;
 	}
-
+	.next-header-before + & {
+		@include oGridRespondTo($until: M) {
+			padding-bottom: 0;
+			position: -webkit-sticky;
+			position: -moz-sticky;
+			position: -ms-sticky;
+			position: -o-sticky;
+			position: sticky;
+			top: 0;
+		}
+	}
 	.next-header__row--primary {
 		position: fixed;
 		left: 0;
@@ -27,6 +37,9 @@
 			&.next-header__row--primary--hidden {
 				transform: translateY(-100%);
 			}
+		}
+		.next-header-before + & {
+			position: relative;
 		}
 	}
 


### PR DESCRIPTION
rather than `fixed`

NB: limited support (http://caniuse.com/#search=sticky), possibly think about a JS fallback