### PR TITLE
Amend: myFT link from icon to text; add hover/focus underline

### DIFF
--- a/src/scss/header/_navigation.scss
+++ b/src/scss/header/_navigation.scss
@@ -197,10 +197,6 @@
 	list-style: none;
 }
 
-.next-header--v2 .next-header__primary-tools__myft {
-	display: inline-block;
-}
-
 .next-header--v2 .next-navigation__membership-tools {
 	margin-bottom: 0.5em;
 

--- a/src/scss/header/_primary-tools.scss
+++ b/src/scss/header/_primary-tools.scss
@@ -61,19 +61,8 @@
 	}
 }
 
-[data-next-anonymous-myft=on] .next-header__primary-tools__myft {
-	display: inline-block;
-}
-
 .next-header__primary-tools__mypage {
 	position: relative;
-}
-
-.next-header__primary-tools__my-page__icon {
-	@include nextIcon(myft-bolder, oColorsGetPaletteColor('white'), 16);
-	content: '';
-	width: 34px;
-	margin: 0 0 -5px;
 }
 
 .next-header__primary-tools__search {
@@ -119,18 +108,6 @@
 		@include oGridRespondTo(M) {
 			display: inline-block;
 		}
-
-		&.next-header__primary-tools__myft {
-			display: inline-block;
-
-			@include oGridRespondTo(M) {
-				display: none;
-			}
-		}
-	}
-
-	.next-navigation-v2__sub-nav .next-header__primary-tools__my-page {
-		padding-right: 15px;
 	}
 
 	.next-header__primary-tools--masthead {
@@ -155,13 +132,6 @@
 		.next-header__primary-tools__link:focus {
 			background-color: transparent;
 		}
-
-		.next-header__primary-tools__my-page__icon {
-			@include nextIcon(myft-bolder, oColorsGetPaletteColor('black'), 16);
-			content: '';
-			width: 34px;
-			margin: 0 0 -5px;
-		}
 	}
 
 	.next-header__search-toggle {
@@ -183,13 +153,6 @@
 
 	.next-header__primary-tools__link {
 		color: $next-header-light-bg;
-	}
-
-	.next-header__primary-tools__my-page__icon {
-		@include nextIcon(myft-bolder, $next-header-light-bg, 16);
-		content: '';
-		width: 34px;
-		margin: 0 0 -5px;
 	}
 }
 

--- a/templates/partials/myft-tools.html
+++ b/templates/partials/myft-tools.html
@@ -1,11 +1,7 @@
 {{#if navigationModel.myFT}}
-	<li class="next-header__primary-tools__item next-header__primary-tools__item--account next-header__primary-tools__item--logged-in next-header__primary-tools__myft">
+	<li class="next-header__primary-tools__item next-header__primary-tools__item--account next-header__primary-tools__item--logged-in">
 		<a class="next-header__primary-tools__link" href="/myft" data-trackable="my-ft">
-			<span class="next-header__primary-tools__my-page next-header__primary-tools__link--inner js-my-page-tool">
-				<i class="next-header__primary-tools__my-page__icon">
-					<span class="n-util-visually-hidden">My FT</span>
-				</i>
-			</span>
+			<span class="next-header__primary-tools__link--inner">myFT</span>
 		</a>
 	</li>
 {{/if}}


### PR DESCRIPTION
cc @ironsidevsquincy 

Loses classes relating to icon; retains those which are used by other links in membership tools (i.e. Sign In / Sign Out / My Account / Subscribe).

Fixes https://github.com/Financial-Times/n-header-footer/pull/104
Fixes https://github.com/Financial-Times/next-front-page/issues/304