### PR TITLE
Tidy masthead in IE8

### DIFF
--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -7,14 +7,16 @@
 		padding-bottom: 0;
 	}
 	.next-header-before + & {
-		@include oGridRespondTo($until: M) {
-			padding-bottom: 0;
-			position: -webkit-sticky;
-			position: -moz-sticky;
-			position: -ms-sticky;
-			position: -o-sticky;
-			position: sticky;
-			top: 0;
+		padding-bottom: 0;
+		position: -webkit-sticky;
+		position: -moz-sticky;
+		position: -ms-sticky;
+		position: -o-sticky;
+		position: sticky;
+		top: 0;
+
+		@include oGridRespondTo(M) {
+			position: relative;
 		}
 	}
 	.next-header__row--primary {

--- a/src/scss/header/_masthead.scss
+++ b/src/scss/header/_masthead.scss
@@ -19,18 +19,10 @@
 	text-align: center;
 
 	.next-header__logo__link {
-		@include nextIcon(brand-ft-masthead, getColor('black'));
+		@include nextIcon(brand-ft-masthead, getColor('white'), 336);
 		display: block;
 		margin: 17px auto;
 		height: 27px;
-		width: 336px;
-
-		.next-header--light-on-dark & {
-			@include nextIcon(brand-ft-masthead, getColor('white'));
-			display: block;
-			height: 27px;
-			width: 336px;
-		}
 
 		&:after {
 			content: none;
@@ -55,20 +47,21 @@
 	}
 
 	.next-header__logo__link {
-		@include nextIcon(brand-ft-masthead, getColor('white'));
+		@include nextIcon(brand-ft-masthead, getColor('white'), 138);
 		display: block;
 		height: 11px;
-		width: 138px;
 		margin: 0 auto;
 
 		@include oGridRespondTo(XS) {
+			@include nextIcon(brand-ft-masthead, getColor('white'), 177);
+			display: block;
 			height: 14px;
-			width: 177px;
 		}
 
 		@include oGridRespondTo(S) {
+			@include nextIcon(brand-ft-masthead, getColor('white'), 265);
+			display: block;
 			height: 21px;
-			width: 265px;
 		}
 		&:after {
 			content: none;

--- a/src/scss/header/_navigation.scss
+++ b/src/scss/header/_navigation.scss
@@ -10,11 +10,12 @@ label > * {
 
 .next-header__primary-nav {
 	float: left;
+	position: absolute;
+	top: 0;
+	left: 0;
 
-	@include oGridRespondTo($until: M) {
-		position: absolute;
-		top: 0;
-		left: 0;
+	@include oGridRespondTo(M) {
+		position: static;
 	}
 }
 


### PR DESCRIPTION
Though menu and search buttons still don't work (as they use `:checked`)

![screen shot 2015-11-02 at 16 22 04](https://cloud.githubusercontent.com/assets/74132/10887221/e00f7834-817d-11e5-8e76-af913c6aac78.jpeg)
