### PR TITLE
remove unused color use case override

### DIFF
--- a/src/scss/header/_colors.scss
+++ b/src/scss/header/_colors.scss
@@ -6,7 +6,6 @@
 
 @include oColorsSetUseCase(nav, text, 'white');
 @include oColorsSetUseCase(nav, background, 'grey-tint5');
-@include oColorsSetUseCase(link-hover, text, 'blue-2');
 @include oColorsSetUseCase(sub-nav, text, 'nav-warm-1');
 @include oColorsSetUseCase(sub-nav-heading, background, 'nav-warm');
 @include oColorsSetUseCase(sub-nav, background, 'cold-2');

--- a/src/scss/header/_navigation.scss
+++ b/src/scss/header/_navigation.scss
@@ -96,10 +96,6 @@ label > * {
 		padding: 0 7px;
 		font-size: 16px;
 	}
-	&:hover,
-	&:focus {
-		@include oColorsFor(link-hover, text);
-	}
 }
 
 .next-navigation__menu__link {


### PR DESCRIPTION
Can I remove this color use case override?

It's leaking into the rest of the site and causing this bug: https://financialtimes.slack.com/archives/ft-next-support/p1449591053000517

As far as I can tell it's always overridden by this rule within the header and footer: https://github.com/Financial-Times/n-header-footer/blob/d1ef6635d5ebb0352600751a5228fcf96e185b93/src/scss/header/_base.scss#L46
![screen shot 2015-12-11 at 15 24 47](https://cloud.githubusercontent.com/assets/4622378/11747509/82f64134-a01b-11e5-9dc0-b2cf7dd2c0fb.png)